### PR TITLE
Increase min version of PHP 7.2

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -75,7 +75,7 @@ jobs:
 
             - name: Install phpunit
               run: |
-                  wget https://phar.phpunit.de/phpunit-5.phar -O phpunit.phar
+                  wget https://phar.phpunit.de/phpunit-8.phar -O phpunit.phar
                   chmod +x phpunit.phar
 
             - name: Run tests

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -17,20 +17,31 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    # lowest dependencies php 7.2
+                    - php-version: '7.1'
+                      composer-flags: '--prefer-lowest --prefer-stable --prefer-dist --no-interaction'
+
                     - php-version: '7.2'
                       composer-flags: '--prefer-lowest --prefer-stable --prefer-dist --no-interaction'
 
-                    # highest dependencies php 7.3
                     - php-version: '7.3'
                       composer-flags: '--prefer-stable --prefer-dist --no-interaction'
 
-                    # highest dependencies php 7.4
                     - php-version: '7.4'
                       composer-flags: '--prefer-stable --prefer-dist --no-interaction'
 
-                    # highest dependencies php 8.0
                     - php-version: '8.0'
+                      composer-flags: '--prefer-stable --prefer-dist --no-interaction'
+
+                    - php-version: '8.1'
+                      composer-flags: '--prefer-stable --prefer-dist --no-interaction'
+
+                    - php-version: '8.2'
+                      composer-flags: '--prefer-stable --prefer-dist --no-interaction'
+
+                    - php-version: '8.3'
+                      composer-flags: '--prefer-stable --prefer-dist --no-interaction'
+
+                    - php-version: '8.4'
                       composer-flags: '--prefer-stable --prefer-dist --no-interaction'
 
         steps:

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -17,9 +17,6 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - php-version: '7.1'
-                      composer-flags: '--prefer-lowest --prefer-stable --prefer-dist --no-interaction'
-
                     - php-version: '7.2'
                       composer-flags: '--prefer-lowest --prefer-stable --prefer-dist --no-interaction'
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "php": ">=7.1.0"
+        "php": ">=7.2.0"
     },
     "replace": {
         "zendframework/zendsearch": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=7.1.0"
     },
     "replace": {
         "zendframework/zendsearch": "self.version"

--- a/library/ZendSearch/Lucene/Search/Weight/Phrase.php
+++ b/library/ZendSearch/Lucene/Search/Weight/Phrase.php
@@ -42,6 +42,11 @@ class Phrase extends AbstractWeight
     private $_idf;
 
     /**
+     * @var float
+     */
+    private $_queryWeight;
+
+    /**
      * Zend_Search_Lucene_Search_Weight_Phrase constructor
      *
      * @param \ZendSearch\Lucene\Search\Query\Phrase $query

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -13,13 +13,6 @@
  */
 error_reporting( E_ALL | E_STRICT );
 
-$phpUnitVersion = PHPUnit_Runner_Version::id();
-if ('@package_version@' !== $phpUnitVersion && version_compare($phpUnitVersion, '3.5.0', '<')) {
-    echo 'This version of PHPUnit (' . PHPUnit_Runner_Version::id() . ') is not supported in Zend Framework 2.x unit tests.' . PHP_EOL;
-    exit(1);
-}
-unset($phpUnitVersion);
-
 /*
  * Determine the root, library, and tests directories of the framework
  * distribution.

--- a/tests/ZendSearch/Lucene/AbstractFSMTest.php
+++ b/tests/ZendSearch/Lucene/AbstractFSMTest.php
@@ -19,7 +19,7 @@ use Zend\Search;
  * @subpackage UnitTests
  * @group      Zend_Search_Lucene
  */
-class AbstractFSMTest extends \PHPUnit_Framework_TestCase
+class AbstractFSMTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/ZendSearch/Lucene/AnalysisTest.php
+++ b/tests/ZendSearch/Lucene/AnalysisTest.php
@@ -24,7 +24,7 @@ use ZendSearch\Lucene\Analysis\Analyzer\Common\Utf8Num;
  * @subpackage UnitTests
  * @group      Zend_Search_Lucene
  */
-class AnalysisTest extends \PHPUnit_Framework_TestCase
+class AnalysisTest extends \PHPUnit\Framework\TestCase
 {
     public function testAnalyzer()
     {

--- a/tests/ZendSearch/Lucene/DocumentTest.php
+++ b/tests/ZendSearch/Lucene/DocumentTest.php
@@ -19,7 +19,7 @@ use ZendSearch\Lucene;
  * @subpackage UnitTests
  * @group      Zend_Search_Lucene
  */
-class DocumentTest extends \PHPUnit_Framework_TestCase
+class DocumentTest extends \PHPUnit\Framework\TestCase
 {
 
     private function _clearDirectory($dirName)

--- a/tests/ZendSearch/Lucene/FieldTest.php
+++ b/tests/ZendSearch/Lucene/FieldTest.php
@@ -18,7 +18,7 @@ use ZendSearch\Lucene\Document;
  * @subpackage UnitTests
  * @group      Zend_Search_Lucene
  */
-class FieldTest extends \PHPUnit_Framework_TestCase
+class FieldTest extends \PHPUnit\Framework\TestCase
 {
     public function testBinary()
     {

--- a/tests/ZendSearch/Lucene/Index/DictionaryLoaderTest.php
+++ b/tests/ZendSearch/Lucene/Index/DictionaryLoaderTest.php
@@ -16,7 +16,7 @@ namespace ZendSearchTest\Lucene\Index;
  * @subpackage UnitTests
  * @group      Zend_Search_Lucene
  */
-class DictionaryLoaderTest extends \PHPUnit_Framework_TestCase
+class DictionaryLoaderTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/ZendSearch/Lucene/Index/FieldInfoTest.php
+++ b/tests/ZendSearch/Lucene/Index/FieldInfoTest.php
@@ -18,7 +18,7 @@ use ZendSearch\Lucene\Index;
  * @subpackage UnitTests
  * @group      Zend_Search_Lucene
  */
-class FieldInfoTest extends \PHPUnit_Framework_TestCase
+class FieldInfoTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/ZendSearch/Lucene/Index/SegmentInfoTest.php
+++ b/tests/ZendSearch/Lucene/Index/SegmentInfoTest.php
@@ -20,7 +20,7 @@ use ZendSearch\Lucene\Storage\File;
  * @subpackage UnitTests
  * @group      Zend_Search_Lucene
  */
-class SegmentInfoTest extends \PHPUnit_Framework_TestCase
+class SegmentInfoTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/ZendSearch/Lucene/Index/SegmentMergerTest.php
+++ b/tests/ZendSearch/Lucene/Index/SegmentMergerTest.php
@@ -19,7 +19,7 @@ use ZendSearch\Lucene\Index;
  * @subpackage UnitTests
  * @group      Zend_Search_Lucene
  */
-class SegmentMergerTest extends \PHPUnit_Framework_TestCase
+class SegmentMergerTest extends \PHPUnit\Framework\TestCase
 {
     public function testMerge()
     {

--- a/tests/ZendSearch/Lucene/Index/TermInfoTest.php
+++ b/tests/ZendSearch/Lucene/Index/TermInfoTest.php
@@ -18,7 +18,7 @@ use ZendSearch\Lucene\Index;
  * @subpackage UnitTests
  * @group      Zend_Search_Lucene
  */
-class TermInfoTest extends \PHPUnit_Framework_TestCase
+class TermInfoTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/ZendSearch/Lucene/Index/TermTest.php
+++ b/tests/ZendSearch/Lucene/Index/TermTest.php
@@ -18,7 +18,7 @@ use ZendSearch\Lucene\Index;
  * @subpackage UnitTests
  * @group      Zend_Search_Lucene
  */
-class TermTest extends \PHPUnit_Framework_TestCase
+class TermTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/ZendSearch/Lucene/Index/TermsPriorityQueueTest.php
+++ b/tests/ZendSearch/Lucene/Index/TermsPriorityQueueTest.php
@@ -19,7 +19,7 @@ use ZendSearch\Lucene\Storage\Directory;
  * @subpackage UnitTests
  * @group      Zend_Search_Lucene
  */
-class TermsPriorityQueueTest extends \PHPUnit_Framework_TestCase
+class TermsPriorityQueueTest extends \PHPUnit\Framework\TestCase
 {
     public function testQueue()
     {

--- a/tests/ZendSearch/Lucene/IndexTest.php
+++ b/tests/ZendSearch/Lucene/IndexTest.php
@@ -22,7 +22,7 @@ use ZendSearch\Lucene\Index;
  */
 class IndexTest extends \PHPUnit\Framework\TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->_clearDirectory(__DIR__ . '/_index/_files');
     }

--- a/tests/ZendSearch/Lucene/IndexTest.php
+++ b/tests/ZendSearch/Lucene/IndexTest.php
@@ -20,7 +20,7 @@ use ZendSearch\Lucene\Index;
  * @subpackage UnitTests
  * @group      Zend_Search_Lucene
  */
-class IndexTest extends \PHPUnit_Framework_TestCase
+class IndexTest extends \PHPUnit\Framework\TestCase
 {
     public function tearDown()
     {

--- a/tests/ZendSearch/Lucene/MultiIndexTest.php
+++ b/tests/ZendSearch/Lucene/MultiIndexTest.php
@@ -18,7 +18,7 @@ use ZendSearch\Lucene;
  * @subpackage UnitTests
  * @group      Zend_Search_Lucene
  */
-class MultiIndexTest extends \PHPUnit_Framework_TestCase
+class MultiIndexTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @covers ZendSearch\Lucene\MultiSearcher::find

--- a/tests/ZendSearch/Lucene/PriorityQueueTest.php
+++ b/tests/ZendSearch/Lucene/PriorityQueueTest.php
@@ -18,7 +18,7 @@ use ZendSearch\Lucene;
  * @subpackage UnitTests
  * @group      Zend_Search_Lucene
  */
-class PriorityQueueTest extends \PHPUnit_Framework_TestCase
+class PriorityQueueTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/ZendSearch/Lucene/PriorityQueueTest.php
+++ b/tests/ZendSearch/Lucene/PriorityQueueTest.php
@@ -27,20 +27,6 @@ class PriorityQueueTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($queue instanceof Lucene\AbstractPriorityQueue);
     }
 
-    public function testPut()
-    {
-        $queue = new testPriorityQueueClass();
-
-        $queue->put(1);
-        $queue->put(100);
-        $queue->put(46);
-        $queue->put(347);
-        $queue->put(11);
-        $queue->put(125);
-        $queue->put(-10);
-        $queue->put(100);
-    }
-
     public function testPop()
     {
         $queue = new testPriorityQueueClass();

--- a/tests/ZendSearch/Lucene/Search23Test.php
+++ b/tests/ZendSearch/Lucene/Search23Test.php
@@ -21,7 +21,7 @@ use ZendSearch\Lucene\Document;
  * @subpackage UnitTests
  * @group      Zend_Search_Lucene
  */
-class Search23Test extends \PHPUnit_Framework_TestCase
+class Search23Test extends \PHPUnit\Framework\TestCase
 {
     public function testQueryParser()
     {

--- a/tests/ZendSearch/Lucene/SearchHighlightTest.php
+++ b/tests/ZendSearch/Lucene/SearchHighlightTest.php
@@ -35,7 +35,7 @@ class SearchHighlightTest extends \PHPUnit\Framework\TestCase
      */
     protected $_defaultPrefixLength;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_wildcardMinPrefix = Query\Wildcard::getMinPrefixLength();
         Query\Wildcard::setMinPrefixLength(0);
@@ -44,7 +44,7 @@ class SearchHighlightTest extends \PHPUnit\Framework\TestCase
         Query\Fuzzy::setDefaultPrefixLength(0);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Query\Wildcard::setMinPrefixLength($this->_wildcardMinPrefix);
         Query\Fuzzy::setDefaultPrefixLength($this->_defaultPrefixLength);

--- a/tests/ZendSearch/Lucene/SearchHighlightTest.php
+++ b/tests/ZendSearch/Lucene/SearchHighlightTest.php
@@ -19,7 +19,7 @@ use ZendSearch\Lucene\Search;
  * @subpackage UnitTests
  * @group      Zend_Search_Lucene
  */
-class SearchHighlightTest extends \PHPUnit_Framework_TestCase
+class SearchHighlightTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Wildcard pattern minimum prefix

--- a/tests/ZendSearch/Lucene/SearchTest.php
+++ b/tests/ZendSearch/Lucene/SearchTest.php
@@ -21,7 +21,7 @@ use ZendSearch\Lucene\Document;
  * @subpackage UnitTests
  * @group      Zend_Search_Lucene
  */
-class SearchTest extends \PHPUnit_Framework_TestCase
+class SearchTest extends \PHPUnit\Framework\TestCase
 {
     public function testQueryParser()
     {

--- a/tests/ZendSearch/Lucene/Storage/DirectoryTest.php
+++ b/tests/ZendSearch/Lucene/Storage/DirectoryTest.php
@@ -19,7 +19,7 @@ use ZendSearch\Lucene\Storage\File;
  * @subpackage UnitTests
  * @group      Zend_Search_Lucene
  */
-class DirectoryTest extends \PHPUnit_Framework_TestCase
+class DirectoryTest extends \PHPUnit\Framework\TestCase
 {
     public function testFilesystem()
     {

--- a/tests/ZendSearch/Lucene/Storage/FileTest.php
+++ b/tests/ZendSearch/Lucene/Storage/FileTest.php
@@ -18,7 +18,7 @@ use ZendSearch\Lucene\Storage\File;
  * @subpackage UnitTests
  * @group      Zend_Search_Lucene
  */
-class FileTest extends \PHPUnit_Framework_TestCase
+class FileTest extends \PHPUnit\Framework\TestCase
 {
     public function testFilesystem()
     {


### PR DESCRIPTION
https://github.com/handcraftedinthealps/ZendSearch/pull/10 requires PHP 7.1.

To make testing we use PHP 7.2 so we can use PHPUnit 8 for testing.

Thx to @rectorphp best toolset to quickly update the PHPUnit tests from PHPUnit 5 to 8 👍 .